### PR TITLE
Fixing guided config after nesting node groups

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -19,15 +19,15 @@ params:
       node_groups:
         default_node_group:
           name: default
-          min_nodes: 1
-          max_nodes: 10
+          min_size: 1
+          max_size: 10
           node_size: Standard_B2s
     - __name: Production
       node_groups:
         default_node_group:
           name: default
-          min_nodes: 1
-          max_nodes: 10
+          min_size: 1
+          max_size: 10
           node_size: Standard_D2s_v3
         additional_node_groups:
           - name: shared


### PR DESCRIPTION
When moving `default_node_group` and `additional_node_groups` under the `node_groups` level, I forgot to make the change with the guided configs. This change broke guided configs, but this PR should fix that.