### PR TITLE
Removing burstable compute sku

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -133,6 +133,7 @@ params:
           type: array
           title: Additional node groups
           description: Additional node groups to provision.
+          default: []
           items:
             type: object
             title: Node group


### PR DESCRIPTION
Burstable compute sku for PSQL and MySQL are being removed, removing from AKS for continuity.