### PR TITLE
adding start and finish characters to the regex

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -5,6 +5,75 @@ source_url: github.com/massdriver-cloud/azure-aks-cluster
 access: "public"
 type: infrastructure
 
+NodeGroup: &node_group
+  required:
+    - name
+    - node_size
+    - min_size
+    - max_size
+  properties:
+    name:
+      type: string
+      title: Name
+      pattern: "^[a-z]{1,}[a-z0-9]{0,11}$"
+      message:
+        pattern: This field only accepts lowercase letters and numbers, with a max length of 12 characters. Changing this forces a deletion and re-creation of the node group.
+    min_size:
+      type: number
+      title: Minimum size
+      description: Minimum number of instances in the node group.
+      default: 1
+      minimum: 1
+      maximum: 1000
+    max_size:
+      type: number
+      title: Maximum size
+      description: Maximum number of instances in the node group.
+      default: 10
+      minimum: 1
+      maximum: 1000
+    node_size:
+      type: string
+      title: Compute size
+      description: Compute size to use in the node group (D = General Purpose, E = Memory Optimized, F = Compute Optimized). Changing this forces a deletion and re-creation of the node group.
+      oneOf:
+        - title: D2s (2 vCores, 8 GiB memory)
+          const: Standard_D2s_v3
+        - title: D4s (4 vCores, 16 GiB memory)
+          const: Standard_D4s_v3
+        - title: D8s (8 vCores, 32 GiB memory)
+          const: Standard_D8s_v3
+        - title: D16s (16 vCores, 64 GiB memory)
+          const: Standard_D16s_v3
+        - title: D32s (32 vCores, 64 GiB memory)
+          const: Standard_D32s_v3
+        - title: D64s (64 vCores, 256 GiB memory)
+          const: Standard_D64s_v3
+        - title: E2s (2 vCores, 16 GiB memory)
+          const: Standard_E2s_v3
+        - title: E4s (4 vCores, 32 GiB memory)
+          const: Standard_E4s_v3
+        - title: E8s (8 vCores, 64 GiB memory)
+          const: Standard_E8s_v3
+        - title: E16s (8 vCores, 128 GiB memory)
+          const: Standard_E16s_v3
+        - title: E32s (32 vCores, 256 GiB memory)
+          const: Standard_E32s_v3
+        - title: E64s (64 vCores, 432 GiB memory)
+          const: Standard_E64s_v3
+        - title: F2s (2 vCores, 4 GiB memory)
+          const: Standard_F2s_v2
+        - title: F4s (4 vCores, 8 GiB memory)
+          const: Standard_F4s_v2
+        - title: F8s (8 vCores, 16 GiB memory)
+          const: Standard_F8s_v2
+        - title: F16s (16 vCores, 32 GiB memory)
+          const: Standard_F16s_v2
+        - title: F32s (32 vCores, 64 GiB memory)
+          const: Standard_F32s_v2
+        - title: F64s (64 vCores, 128 GiB memory)
+          const: Standard_F64s_v2
+
 steps:
   - path: src
     provisioner: terraform
@@ -69,74 +138,7 @@ params:
           type: object
           title: Default node group
           description: Configuration of the node group.
-          required:
-            - name
-            - node_size
-            - min_size
-            - max_size
-          properties:
-            name:
-              type: string
-              title: Name
-              description: The name of the node group.
-              pattern: "[a-z]{1,}[a-z0-9]{0,11}"
-              message:
-                pattern: This field only accepts lowercase letters and numbers, with a max length of 12 characters. Changing this forces a deletion and re-creation of the node group.
-            min_size:
-              type: number
-              title: Minimum size
-              description: Minimum number of instances in the node group.
-              default: 1
-              minimum: 1
-              maximum: 1000
-            max_size:
-              type: number
-              title: Maximum size
-              description: Maximum number of instances in the node group.
-              default: 10
-              minimum: 1
-              maximum: 1000
-            node_size:
-              type: string
-              title: Compute size
-              description: Compute size to use in the node group (D = General Purpose, E = Memory Optimized, F = Compute Optimized). Changing this forces a deletion and re-creation of the node group.
-              oneOf:
-                - title: D2s (2 vCores, 8 GiB memory)
-                  const: Standard_D2s_v3
-                - title: D4s (4 vCores, 16 GiB memory)
-                  const: Standard_D4s_v3
-                - title: D8s (8 vCores, 32 GiB memory)
-                  const: Standard_D8s_v3
-                - title: D16s (16 vCores, 64 GiB memory)
-                  const: Standard_D16s_v3
-                - title: D32s (32 vCores, 64 GiB memory)
-                  const: Standard_D32s_v3
-                - title: D64s (64 vCores, 256 GiB memory)
-                  const: Standard_D64s_v3
-                - title: E2s (2 vCores, 16 GiB memory)
-                  const: Standard_E2s_v3
-                - title: E4s (4 vCores, 32 GiB memory)
-                  const: Standard_E4s_v3
-                - title: E8s (8 vCores, 64 GiB memory)
-                  const: Standard_E8s_v3
-                - title: E16s (8 vCores, 128 GiB memory)
-                  const: Standard_E16s_v3
-                - title: E32s (32 vCores, 256 GiB memory)
-                  const: Standard_E32s_v3
-                - title: E64s (64 vCores, 432 GiB memory)
-                  const: Standard_E64s_v3
-                - title: F2s (2 vCores, 4 GiB memory)
-                  const: Standard_F2s_v2
-                - title: F4s (4 vCores, 8 GiB memory)
-                  const: Standard_F4s_v2
-                - title: F8s (8 vCores, 16 GiB memory)
-                  const: Standard_F8s_v2
-                - title: F16s (16 vCores, 32 GiB memory)
-                  const: Standard_F16s_v2
-                - title: F32s (32 vCores, 64 GiB memory)
-                  const: Standard_F32s_v2
-                - title: F64s (64 vCores, 128 GiB memory)
-                  const: Standard_F64s_v2
+          <<: *node_group
         additional_node_groups:
           type: array
           title: Additional node groups
@@ -144,73 +146,7 @@ params:
           items:
             type: object
             title: Node group
-            required:
-              - name
-              - node_size
-              - min_size
-              - max_size
-            properties:
-              name:
-                type: string
-                title: Name
-                pattern: "[a-z]{1,}[a-z0-9]{0,11}"
-                message:
-                  pattern: This field only accepts lowercase letters and numbers, with a max length of 12 characters. Changing this forces a deletion and re-creation of the node group.
-              min_size:
-                type: number
-                title: Minimum size
-                description: Minimum number of instances in the node group.
-                default: 1
-                minimum: 1
-                maximum: 1000
-              max_size:
-                type: number
-                title: Maximum size
-                description: Maximum number of instances in the node group.
-                default: 10
-                minimum: 1
-                maximum: 1000
-              node_size:
-                type: string
-                title: Compute size
-                description: Compute size to use in the node group (D = General Purpose, E = Memory Optimized, F = Compute Optimized). Changing this forces a deletion and re-creation of the node group.
-                oneOf:
-                  - title: D2s (2 vCores, 8 GiB memory)
-                    const: Standard_D2s_v3
-                  - title: D4s (4 vCores, 16 GiB memory)
-                    const: Standard_D4s_v3
-                  - title: D8s (8 vCores, 32 GiB memory)
-                    const: Standard_D8s_v3
-                  - title: D16s (16 vCores, 64 GiB memory)
-                    const: Standard_D16s_v3
-                  - title: D32s (32 vCores, 64 GiB memory)
-                    const: Standard_D32s_v3
-                  - title: D64s (64 vCores, 256 GiB memory)
-                    const: Standard_D64s_v3
-                  - title: E2s (2 vCores, 16 GiB memory)
-                    const: Standard_E2s_v3
-                  - title: E4s (4 vCores, 32 GiB memory)
-                    const: Standard_E4s_v3
-                  - title: E8s (8 vCores, 64 GiB memory)
-                    const: Standard_E8s_v3
-                  - title: E16s (8 vCores, 128 GiB memory)
-                    const: Standard_E16s_v3
-                  - title: E32s (32 vCores, 256 GiB memory)
-                    const: Standard_E32s_v3
-                  - title: E64s (64 vCores, 432 GiB memory)
-                    const: Standard_E64s_v3
-                  - title: F2s (2 vCores, 4 GiB memory)
-                    const: Standard_F2s_v2
-                  - title: F4s (4 vCores, 8 GiB memory)
-                    const: Standard_F4s_v2
-                  - title: F8s (8 vCores, 16 GiB memory)
-                    const: Standard_F8s_v2
-                  - title: F16s (16 vCores, 32 GiB memory)
-                    const: Standard_F16s_v2
-                  - title: F32s (32 vCores, 64 GiB memory)
-                    const: Standard_F32s_v2
-                  - title: F64s (64 vCores, 128 GiB memory)
-                    const: Standard_F64s_v2
+            <<: *node_group
     core_services:
       type: object
       title: Core Services


### PR DESCRIPTION
Customer entered `node1-demo` and the regex matched the first two characters. This adds start end end string matches to verify that the entire string meets the criteria.

![image](https://user-images.githubusercontent.com/3393271/212458681-4e0ac22b-ef57-4d22-a142-80d568a52754.png)

