### PR TITLE
Update regex of node group

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -15,7 +15,7 @@ NodeGroup: &node_group
     name:
       type: string
       title: Name
-      pattern: "^[a-z]{1,}[a-z0-9]{0,11}$"
+      pattern: "^[a-z]{1,1}[a-z0-9]{0,11}$"
       message:
         pattern: This field only accepts lowercase letters and numbers, with a max length of 12 characters. Changing this forces a deletion and re-creation of the node group.
     min_size:


### PR DESCRIPTION
The regex before it was allowing unlimited number of characters. This update limits the maximum to 12 characters.