### PR TITLE
Temp name for default node pool

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -37,13 +37,14 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    name                = var.node_groups.default_node_group.name
-    vm_size             = var.node_groups.default_node_group.node_size
-    min_count           = var.node_groups.default_node_group.min_size
-    max_count           = var.node_groups.default_node_group.max_size
-    vnet_subnet_id      = var.vnet.data.infrastructure.default_subnet_id
-    enable_auto_scaling = true
-    tags                = var.md_metadata.default_tags
+    name                        = var.node_groups.default_node_group.name
+    vm_size                     = var.node_groups.default_node_group.node_size
+    min_count                   = var.node_groups.default_node_group.min_size
+    max_count                   = var.node_groups.default_node_group.max_size
+    vnet_subnet_id              = var.vnet.data.infrastructure.default_subnet_id
+    temporary_name_for_rotation = "${var.node_groups.default_node_group.name}temp"
+    enable_auto_scaling         = true
+    tags                        = var.md_metadata.default_tags
   }
 
   identity {


### PR DESCRIPTION
Can't change VM SKU size for AKS default node pool because it requires this param that isn't set. Setting this param so that VM size can be changed w/o destroying AKS first.