### PR TITLE
Adding max length for node resource group

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,3 +1,8 @@
+locals {
+  node_rg_max_length = 80
+  node_rg_name       = substr("MC_${var.md_metadata.name_prefix}_${var.md_metadata.name_prefix}_${var.vnet.specs.azure.region}", 0, local.node_rg_max_length)
+}
+
 resource "azurerm_resource_group" "main" {
   name     = var.md_metadata.name_prefix
   location = var.vnet.specs.azure.region
@@ -17,6 +22,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   location                          = var.vnet.specs.azure.region
   resource_group_name               = azurerm_resource_group.main.name
   dns_prefix                        = "${var.md_metadata.name_prefix}-dns"
+  node_resource_group               = local.node_rg_name
   kubernetes_version                = var.cluster.kubernetes_version
   azure_policy_enabled              = true
   role_based_access_control_enabled = true


### PR DESCRIPTION
While this is a breaking change normally...
![image](https://github.com/massdriver-cloud/azure-aks-cluster/assets/8037512/ba05cf57-0ce9-471a-918d-042a87a86e25)
currently, AKS doesn't let you deploy if the node resource group name is > 80 characters. So, because the terraform fails to deploy, there shouldn't be any existing AKS clusters where the name would change. The name is identical to what gets stored into the statefile:
![image](https://github.com/massdriver-cloud/azure-aks-cluster/assets/8037512/914a0a48-e7ce-4320-a1cf-7fe33ded8b77)
This name is auto generated, so I constructed a string to match it, and then just set a max length of 80. I tested this locally, and this was the result of the upgrade with a character count < 80:
![image](https://github.com/massdriver-cloud/azure-aks-cluster/assets/8037512/4936f39a-1bd5-48a9-840a-0fe957359824)
