### PR TITLE
Adding support for multiple DNS zones

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -269,7 +269,6 @@ params:
           type: array
           title: Azure DNS Zone
           description: Add an Azure DNS Zone associated with this cluster to allow Kubernetes to automatically manage DNS records and SSL certificates.
-          maxItems: 1
           items:
             type: string
     monitoring:


### PR DESCRIPTION
Customer requested.

Currently deploying 2 external DNS instances, each configured with their own DNS zone. This is a workaround for the resource group limitation.

Issue currently facing: records are not being created in Azure, though cannot find any issues with pods/endpoints/secrets listed in kubernetes.

Related: https://github.com/massdriver-cloud/terraform-modules/pull/204